### PR TITLE
Fix auth token refresh bug and update tests

### DIFF
--- a/src/app.controller.spec.ts
+++ b/src/app.controller.spec.ts
@@ -15,8 +15,10 @@ describe('AppController', () => {
   });
 
   describe('root', () => {
-    it('should return "Hello World!"', () => {
-      expect(appController.getHealthCheckStatus()).toBe('Hello World!');
+    it('should return the health check status', () => {
+      expect(appController.getHealthCheckStatus()).toBe(
+        'Health Check OK - All systems operational',
+      );
     });
   });
 });

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -236,7 +236,7 @@ export class AuthController {
         HttpStatus.OK,
         true,
         ApiResponseMessages.SUCCESS,
-        { accessToken: result.refreshToken },
+        { accessToken: result.accessToken },
         null,
       );
     } catch (error) {

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -75,7 +75,7 @@ export class AuthService {
     throw new UnauthorizedException('Invalid credentials');
   }
 
-  async refreshToken(refreshToken: string): Promise<{ refreshToken: string }> {
+  async refreshToken(refreshToken: string): Promise<{ accessToken: string }> {
     try {
       const payload = await this.jwtService.verifyAsync(refreshToken, {
         secret: this.configService.get('JWT_REFRESH_SECRET'),
@@ -104,7 +104,7 @@ export class AuthService {
         timestamp: new Date()
       });
 
-      return { refreshToken: accessToken };
+      return { accessToken };
     } catch (error) {
       this.loggingService.error('Token refresh error', error.stack);
       throw new UnauthorizedException('Invalid refresh token');

--- a/src/auth/guards/jwt-role.guard.ts
+++ b/src/auth/guards/jwt-role.guard.ts
@@ -1,4 +1,4 @@
-// src/auth/guards/jwt-roles.guard.ts
+// src/auth/guards/jwt-role.guard.ts
 
 import {
   Injectable,

--- a/src/brand-management/dto/brand-info.dto.ts
+++ b/src/brand-management/dto/brand-info.dto.ts
@@ -1,4 +1,4 @@
-// src/brand-management/dto/create-brand.dto.ts
+// src/brand-management/dto/brand-info.dto.ts
 
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -19,6 +19,6 @@ describe('AppController (e2e)', () => {
     return request(app.getHttpServer())
       .get('/')
       .expect(200)
-      .expect('Hello World!');
+      .expect('Health Check OK - All systems operational');
   });
 });


### PR DESCRIPTION
## Summary
- correct reference comment in brand-info DTO
- fix filename in JWT role guard comment
- fix token refresh return value
- update refresh-token controller response
- adjust unit & e2e tests for health check message

## Testing
- `yarn test`
- `yarn test:e2e` *(fails: Cannot find module 'src/common/api-response-messages')*

------
https://chatgpt.com/codex/tasks/task_e_6840104d5500832591ac4e3ce4d049a6